### PR TITLE
Add input labels to username and password fields

### DIFF
--- a/custom_components/lacrosseview/const.py
+++ b/custom_components/lacrosseview/const.py
@@ -1,1 +1,3 @@
 DOMAIN = "lacrosseview"
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"

--- a/custom_components/lacrosseview/translations/en.json
+++ b/custom_components/lacrosseview/translations/en.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "title": "La Crosse View",
+    "step": {
+      "user": {
+        "title": "Fill in your La Crosse credentials",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "auth_error": "La Crosse View authentication failed. Are your credentials correct?"
+    },
+    "abort": {
+      "already_configured": "La Crosse View is already configured"
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/regulad/hass-lacrosseview/issues/9

I think this should add labels to the username and password fields!

<img width="421" alt="Screen Shot 2022-06-07 at 12 42 08 AM" src="https://user-images.githubusercontent.com/1182187/172324439-de3b4b54-61e9-4c53-acb5-181d6bfc19e1.png">
