### PR TITLE
Replace current async_setup_platforms function with async_forward_ent…

### DIFF
--- a/custom_components/lacrosseview/__init__.py
+++ b/custom_components/lacrosseview/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ws = WeatherStation()
     uuid = entry.data[CONF_USERNAME]
     await hass.loop.run_in_executor(None, partial(ws.start, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]))
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     domain_data[uuid] = ws
     return True
 


### PR DESCRIPTION
…ry_setups, which will prevent the integration failing to start in Home Assistant 2023.5

Addressing https://github.com/regulad/hass-lacrosseview/issues/13